### PR TITLE
Added a General Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Submit a bug report
+title: "[Bug]: "
+  required: true
+labels: ["bug", "triage"]
+assignees:
+  - ' '
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+      Example: steps to reproduce the behavior:
+        In X environment ___.
+        When I do ____. 
+        This happens ____.
+        I get error ____.
+        I expect ____ to happen. 
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    attributes:
+     label: Anything else?
+      description: |
+       Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        #### Please utilize GitHubs Branch creation within issue to create and name branch. 
+        Branches MUST have descriptive names that start with the Issue number and then either the `fix/` or `feature/` prefixes. Good examples are: `10/fix/signin-issue` or `22/feature/issue-templates`.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_template.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_template.yml
@@ -1,0 +1,39 @@
+name: Documentation Missing
+description: Current Documentation is not clear or missing needed info
+title: "[Documentation]: "
+  required: true
+labels: ["documentation", "triage"]
+assignees:
+  - ' '
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        #### Please utilize GitHubs Branch creation within issue to create and name branch. 
+        Branches MUST have descriptive names that start with the Issue number and then either the `fix/` or `feature/` prefixes. Good examples are: `10/fix/signin-issue` or `22/feature/issue-templates`.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Documentation description 
+      description: A description of what the documentation issue.
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Is this missing info?
+      description: What type of Documentation Update?
+      options:
+        - label: Documentation Missing Info
+        - label: Current Documentation Not Clear
+        - label: Additional Document for Org. Collaborator Use
+      validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Anything else? Need to be considered or known about this feature?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,0 +1,77 @@
+name: Confirmed Feature Ticket
+description: Confirmed Feature that needs to be Implemented
+title: "[Feature]: <CRUD ACTION if applicable> <feature description>"
+  required: true
+labels: ["feature"]
+assignees:
+  - ' '
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        #### Please utilize GitHubs Branch creation within issue to create and name branch. 
+        Branches MUST have descriptive names that start with the Issue number and then either the `fix/` or `feature/` prefixes. Good examples are: `10/fix/signin-issue` or `22/feature/issue-templates`.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Feature description 
+      description: A concise description of what this feature will do.
+    validations:
+      required: true
+  - type: checkboxes
+  attributes:
+    label: Is this a route?
+    description: Does this feature have to do with a incoming request/routing?
+    options:
+    - label: Yes, this is for a new route
+    - label: Yes, this is for an existing route
+    - label: No, this is for a design/build/architecture feature/change
+      required: true
+  - type: dropdown
+    attributes:
+      label: CRUD Action
+      description: Select the CRUD Action for the route
+      options:
+        - label: N/A
+        - label: GET
+        - label: POST
+        - label: PATCH
+        - label: PUT
+        - label: DELETE
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Route Path / Description
+      description: Rest of route path OR indicate what the type of feature is if not route
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Success - JSON Contract Example
+      description: "Success: JSON Contract Example"
+      render: shell
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Success - Return status code
+      description: "Success: Return status code"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Fail - JSON Contract Example(s)
+      description: "Error: JSON Contract Example(s) - Indicate Return Status Code before each example"
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Anything else? Need to be considered or known about this feature?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,27 @@
+---
+name: General Issue
+about: Basic Template for either bug or feature request
+title: "[Bug/Feature]: "
+labels: triage
+assignees: ''
+
+---
+
+## I'm submitting a ...
+
+- [ ] bug report
+- [ ] feature request
+
+## What is the current behavior?
+
+## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
+
+## What is the expected behavior?
+
+## What is the motivation/use case for changing the behavior?
+
+## Please tell us about your environment:
+
+Version:
+Browser:
+Language:


### PR DESCRIPTION
Added Pull request Template and Issue Templates using YML setup

- If YMLs don't work after merge, I will update the branch so templates are markdown files
- utilized this info from GitHub
  - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
  - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#example-of-markdown